### PR TITLE
feat|fix: adding attribute to skip null properties

### DIFF
--- a/src/Octokit.GraphQL.Core/Core/Serializers/SerializeIfNotNullAttribute.cs
+++ b/src/Octokit.GraphQL.Core/Core/Serializers/SerializeIfNotNullAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Octokit.GraphQL.Core.Serializers
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SerializeIfNotNull : Attribute
+    {
+    }
+}

--- a/src/Octokit.GraphQL/Model/RuleParametersInput.cs
+++ b/src/Octokit.GraphQL/Model/RuleParametersInput.cs
@@ -1,7 +1,6 @@
 namespace Octokit.GraphQL.Model
 {
-    using System;
-    using System.Collections.Generic;
+    using Core.Serializers;
 
     /// <summary>
     /// Specifies the parameters for a `RepositoryRule` object. Only one of the fields should be specified.
@@ -11,51 +10,61 @@ namespace Octokit.GraphQL.Model
         /// <summary>
         /// Parameters used for the `update` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public UpdateParametersInput Update { get; set; }
 
         /// <summary>
         /// Parameters used for the `required_deployments` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public RequiredDeploymentsParametersInput RequiredDeployments { get; set; }
 
         /// <summary>
         /// Parameters used for the `pull_request` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public PullRequestParametersInput PullRequest { get; set; }
 
         /// <summary>
         /// Parameters used for the `required_status_checks` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public RequiredStatusChecksParametersInput RequiredStatusChecks { get; set; }
 
         /// <summary>
         /// Parameters used for the `commit_message_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public CommitMessagePatternParametersInput CommitMessagePattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `commit_author_email_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public CommitAuthorEmailPatternParametersInput CommitAuthorEmailPattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `committer_email_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public CommitterEmailPatternParametersInput CommitterEmailPattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `branch_name_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public BranchNamePatternParametersInput BranchNamePattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `tag_name_pattern` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public TagNamePatternParametersInput TagNamePattern { get; set; }
 
         /// <summary>
         /// Parameters used for the `workflows` rule type
         /// </summary>
+        [SerializeIfNotNull]
         public WorkflowsParametersInput Workflows { get; set; }
     }
 }


### PR DESCRIPTION
Adding the [SerializeIfNotNullAttribute] which can be applied to properties serialized by the QuerySerializer to indicate they should never be serialized when null.

As a proof of concept, the RuleParameterInput used in the creation of rulesets for the repository was failing due to null properties being seralized into the final output. This code now functions as expected.

I did not make a global change to no longer serialized all null values as I anticipate that there are "side effects" we depend on where there are expected null serialzations that will break if such a change is made.

This is an "opt-in" feature that does not disturb the greater echosystem that may depend on these "side effects".

octokit/octokit.graphql.net#320

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

